### PR TITLE
feat: Require color and ratio in add-official-template script

### DIFF
--- a/scripts/add-official-template.mjs
+++ b/scripts/add-official-template.mjs
@@ -1,6 +1,7 @@
 import { createClient } from "@supabase/supabase-js";
 import minimist from "minimist";
 import dotenv from "dotenv";
+import { ROULETTE_COLORS } from "../src/constants/roulette.ts";
 
 // Load environment variables from .env file
 dotenv.config();
@@ -64,9 +65,36 @@ const localizedDescription = supportedLanguages.reduce((acc, lang) => {
 async function addOfficialTemplate() {
   console.log("Adding new official template...");
 
+  // Add color and ratio to each item if they are not provided
+  const itemsWithDefaults = parsedItems.map((item, index) => {
+    const newItem = { ...item };
+    if (!newItem.color) {
+      newItem.color = ROULETTE_COLORS[index % ROULETTE_COLORS.length];
+    }
+    if (newItem.ratio === undefined || newItem.ratio === null) {
+      newItem.ratio = 1;
+    }
+    return newItem;
+  });
+
+  // Final validation to ensure all items have the required properties
+  if (
+    !itemsWithDefaults.every(
+      (item) =>
+        "name" in item &&
+        "color" in item &&
+        "ratio" in item &&
+        typeof item.ratio === "number"
+    )
+  ) {
+    throw new Error(
+      "All items must have a name, color, and a numeric ratio after processing."
+    );
+  }
+
   const rouletteData = {
     title: title,
-    items: parsedItems,
+    items: itemsWithDefaults,
     description: localizedDescription,
     // This ID should match the one in src/constants/common.ts
     user_id: "8e258865-4c59-4bac-a98b-44de8a2ff5c7",


### PR DESCRIPTION
The `add-official-template.mjs` script has been updated to ensure that all roulette items have `color` and `ratio` properties before being saved to the database.

- If `color` is not provided for an item, a default color is assigned from the `ROULETTE_COLORS` constant.
- If `ratio` is not provided, it defaults to `1`.
- Added a final validation step to guarantee that all items have the required `name`, `color`, and `ratio` properties before insertion.

This change makes the script more robust and ensures data consistency for official templates, while providing sensible defaults for easier use.