### PR TITLE
フッターのリンクカテゴリーを、より直感的で分かりやすい構造に再編成しました。

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -36,10 +36,10 @@ const Footer = () => {
               <p className="text-white/70">{t("footer.tagline")}</p>
             </div>
 
-            {/* サービスリンク */}
+            {/* 主な機能リンク */}
             <div>
               <h3 className="font-semibold mb-4 tracking-widest uppercase text-yellow-300">
-                {t("footer.services")}
+                {t("footer.mainFeatures")}
               </h3>
               <nav className="flex flex-col space-y-3">
                 <Link
@@ -48,24 +48,11 @@ const Footer = () => {
                 >
                   {t("roulette.title")}
                 </Link>
-                {/* テンプレートページへのリンクを追加 */}
                 <Link
                   href={`/${locale}/templates`}
                   className="text-sm hover:text-yellow-300 underline transition-colors"
                 >
-                  {t("templates.template")}
-                </Link>
-                <Link
-                  href={`/${locale}/articles`}
-                  className="text-sm hover:text-yellow-300 underline transition-colors"
-                >
-                  {t("articles.title")}
-                </Link>
-                <Link
-                  href={`/${locale}/how-to-use`}
-                  className="text-sm hover:text-yellow-300 underline transition-colors"
-                >
-                  {t("howToUse.title")}
+                  {t("templates.title")}
                 </Link>
                 {user && (
                   <Link
@@ -78,17 +65,29 @@ const Footer = () => {
               </nav>
             </div>
 
-            {/* 法務リンク */}
+            {/* サポートリンク */}
             <div>
               <h3 className="font-semibold mb-4 tracking-widest uppercase text-yellow-300">
-                {t("footer.legal")}
+                {t("footer.support")}
               </h3>
               <nav className="flex flex-col space-y-3">
                 <Link
-                  href={`/${locale}/about`}
+                  href={`/${locale}/how-to-use`}
                   className="text-sm hover:text-yellow-300 underline transition-colors"
                 >
-                  {t("about.title")}
+                  {t("howToUse.title")}
+                </Link>
+                <Link
+                  href={`/${locale}/articles`}
+                  className="text-sm hover:text-yellow-300 underline transition-colors"
+                >
+                  {t("articles.title")}
+                </Link>
+                <Link
+                  href={`/${locale}/faq`}
+                  className="text-sm hover:text-yellow-300 underline transition-colors"
+                >
+                  {t("faq.title")}
                 </Link>
                 <Link
                   href={`/${locale}/contact`}
@@ -96,11 +95,20 @@ const Footer = () => {
                 >
                   {t("contact.title")}
                 </Link>
+              </nav>
+            </div>
+
+            {/* サイト情報リンク */}
+            <div>
+              <h3 className="font-semibold mb-4 tracking-widest uppercase text-yellow-300">
+                {t("footer.siteInfo")}
+              </h3>
+              <nav className="flex flex-col space-y-3">
                 <Link
-                  href={`/${locale}/faq`}
+                  href={`/${locale}/about`}
                   className="text-sm hover:text-yellow-300 underline transition-colors"
                 >
-                  {t("faq.title")}
+                  {t("about.title")}
                 </Link>
                 <Link
                   href={`/${locale}/privacy-policy`}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -23,19 +23,19 @@ const Footer = () => {
         transition={{ duration: 0.6, delay: 0.6 }}
       >
         <div className="max-w-7xl mx-auto px-6 py-12">
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
-            {/* ブランドセクション */}
-            <div className="col-span-1">
-              <Link
-                href={`/${locale}`}
-                className="flex items-center gap-2 mb-4"
-              >
-                <Sparkles className="text-yellow-300" size={28} />
-                <span className="text-2xl font-bold">{t("title")}</span>
-              </Link>
-              <p className="text-white/70">{t("footer.tagline")}</p>
-            </div>
+          {/* ブランドセクション */}
+          <div className="mb-8">
+            <Link
+              href={`/${locale}`}
+              className="flex items-center gap-2 mb-4 w-fit"
+            >
+              <Sparkles className="text-yellow-300" size={28} />
+              <span className="text-2xl font-bold">{t("title")}</span>
+            </Link>
+            <p className="text-white/70">{t("footer.tagline")}</p>
+          </div>
 
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
             {/* 主な機能リンク */}
             <div>
               <h3 className="font-semibold mb-4 tracking-widest uppercase text-yellow-300">

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -347,9 +347,9 @@
   },
   "footer": {
     "copyright": "Web Roulette. All rights reserved.",
-    "services": "Services",
-    "howToUse": "How to Use",
-    "legal": "Legal",
+    "mainFeatures": "Main Features",
+    "support": "Support",
+    "siteInfo": "Site Info",
     "social": "Social",
     "tagline": "Instantly create and share your own custom roulettes."
   },

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -325,9 +325,9 @@
   },
   "footer": {
     "copyright": "Ruleta Web. Todos los derechos reservados.",
-    "services": "Servicios",
-    "howToUse": "Cómo usar",
-    "legal": "Legal",
+    "mainFeatures": "Funciones principales",
+    "support": "Soporte",
+    "siteInfo": "Información del sitio",
     "social": "Social",
     "tagline": "Crea y comparte instantáneamente tus propias ruletas personalizadas."
   },

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -325,9 +325,9 @@
   },
   "footer": {
     "copyright": "Roulette en Ligne. Tous droits réservés.",
-    "services": "Services",
-    "howToUse": "Comment utiliser",
-    "legal": "Légal",
+    "mainFeatures": "Fonctionnalités principales",
+    "support": "Support",
+    "siteInfo": "Informations sur le site",
     "social": "Social",
     "tagline": "Créez et partagez instantanément vos propres roulettes personnalisées."
   },

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -347,8 +347,9 @@
   },
   "footer": {
     "copyright": "Webでルーレット. All rights reserved.",
-    "services": "サービス",
-    "legal": "法務",
+    "mainFeatures": "主な機能",
+    "support": "サポート",
+    "siteInfo": "サイト情報",
     "social": "ソーシャル",
     "tagline": "オリジナルのカスタムルーレットをすぐに作成・共有できます。"
   },


### PR DESCRIPTION
主な変更点:
- フッターのカテゴリーを「主な機能」「サポート」「サイト情報」に更新しました。
- 各カテゴリーに合わせて、フッター内のリンクを再配置しました。
- 新しいカテゴリー名に対応する翻訳キーを、日本語、英語、スペイン語、フランス語の `common.json` ファイルに追加しました。
- 「テンプレート」のリンクテキストを「テンプレートから探す」に更新しました。